### PR TITLE
Express 5 uses path-to-regexp v8+, which no longer accepts bare * as a wildcard route.

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -25,7 +25,7 @@ router.get('/', function(req, res, next) {
 });
 
 // 404 fallback
-router.get('*', function(req, res){
+router.get('*path', function(req, res){
   res.status(404)
   res.render('404')
 });


### PR DESCRIPTION
Fixes this error, likely caused by merging everything Dependabot told us to
<img width="1215" height="608" alt="image" src="https://github.com/user-attachments/assets/609a1337-5baa-4df2-8424-9bc5b09a4d84" />
